### PR TITLE
Require database name in Cloudant URL

### DIFF
--- a/src/containers/ListContainer.js
+++ b/src/containers/ListContainer.js
@@ -6,7 +6,7 @@ import PouchDB from 'pouchdb';
 import Credentials from '../secret';
 
 const localDB = new PouchDB('shopping_list');
-const remoteDB = new PouchDB(Credentials.cloudant_url + '/shopping_list');
+const remoteDB = new PouchDB(Credentials.cloudant_url);
 
 const containerStyle = {
   marginTop: '2%',

--- a/src/sample-secret.js
+++ b/src/sample-secret.js
@@ -1,5 +1,5 @@
 const Credentials = {
-  "cloudant_url": "my_cloudant_url_from_bluemix"
+  "cloudant_url": "my_cloudant_url/my_database_name"
 }
 
 export default Credentials;


### PR DESCRIPTION
This takes out the hard-coded "shopping-list" database and requests that the user specify the database in the Cloudant URL.

This fixes issue #2 