### PR TITLE
Updates to README and Cloudant URL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Nick Kasten
 IBM Dev Intern
 Summer 2017
 
-## Installation
+## Quick Start
 
 1. `git clone` this repo and `cd` into the project's root directory.
 2. Execute `mv src/sample-secret.js src/secret.js` from the root directory.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,17 @@ Summer 2017
 
 1. `git clone` this repo and `cd` into the project's root directory.
 2. Execute `mv src/sample-secret.js src/secret.js` from the root directory.
-3. Add your Cloudant URL (found in Credentials on Bluemix) to `src/secret.js`.
-4. Execute `npm install` from the root directory of the project to install dependencies.
-5. Use `npm start` to start the development server and launch your app.
-6. Navigate to `http://localhost:3000` to see your app runninig in your browser.
+3. Create a new database in your Cloudant instance.
+4. Enable CORS in Cloudant and add http://localhost:3000 to the list of origin domains.
+5. Add your Cloudant URL to `src/secret.js`.
+6. Execute `npm install` from the root directory of the project to install dependencies.
+7. Use `npm start` to start the development server and launch your app.
+8. Navigate to `http://localhost:3000` to see your app runninig in your browser.
+
+## Testing Service Workers/Offline Support
+
+1. In Cloudant add http://localhost:5000 to the list of origin domains.
+2. Run `npm run build` to run a production build.
+3. Run `npm install -g serve` to install serve.
+4. Run `serve -s build` to serve the production build.
+5. Navigate to `http://localhost:5000` to see your app runninig in your browser.

--- a/src/containers/ListContainer.js
+++ b/src/containers/ListContainer.js
@@ -6,7 +6,7 @@ import PouchDB from 'pouchdb';
 import Credentials from '../secret';
 
 const localDB = new PouchDB('shopping_list');
-const remoteDB = new PouchDB(Credentials.cloudant_url + '/shopping_list');
+const remoteDB = new PouchDB(Credentials.cloudant_url);
 
 const containerStyle = {
   marginTop: '2%',

--- a/src/sample-secret.js
+++ b/src/sample-secret.js
@@ -1,5 +1,5 @@
 const Credentials = {
-  "cloudant_url": "my_cloudant_url_from_bluemix"
+  "cloudant_url": "my_cloudant_url/my_database_name"
 }
 
 export default Credentials;


### PR DESCRIPTION
This takes out the hard-coded "shopping-list" database and requests that the user specify the database in the Cloudant URL.

This fixes issue #2

This also includes updates to the README for setting up Cloudant and testing service workers.

This address issues #4  and #5 